### PR TITLE
Add --tail argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,8 @@
 
 A real time viewer for the log.txt file of *The Binding of Isaac: Repentance*.
 
-## Requirements
-
-`pip install -r requirements`
-
 ## Usage
 
-Simply run `python main.py`.
-
-To list arguments run `python main.py -help`
+- `pip install -r requirements` (to install the required dependencies)
+- `python main.py --help` (to list the possible arguments)
+- `python main.py` (to run the program)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # isaac-log-viewer
 
 A real time viewer for the log.txt file of *The Binding of Isaac: Repentance*.
+
+## Requirements
+
+`pip install -r requirements`
+
+## Usage
+
+Simply run `python main.py`.
+
+To list arguments run `python main.py -help`

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 import os
 import time
 import getpass
+import argparse
+
 
 USERNAME = getpass.getuser()
 # EXPANSION_LEVEL = "Rebirth"
@@ -29,10 +31,21 @@ cached_length = 0
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Log viewer for The Binding of Isaac.")
+    parser.add_argument(
+        "-t",
+        "--tail",
+        type=int,
+        required=False,
+        help="show last N of log lines",
+        default=0,
+    )
+    args = parser.parse_args()
+
     while True:
         file_size = os.path.getsize(LOG_FILE_PATH)
         if has_log_changed(file_size):
-            read_log(file_size)
+            read_log(file_size, args)
         time.sleep(0.1)
 
 
@@ -40,7 +53,7 @@ def has_log_changed(file_size: int):
     return file_size != cached_length
 
 
-def read_log(file_size: int):
+def read_log(file_size: int, args: argparse.Namespace):
     global log_file_handle
     global cached_length
 
@@ -53,11 +66,16 @@ def read_log(file_size: int):
 
     cached_length = file_size
     new_log_content = log_file_handle.read()
-    parse_log(new_log_content)
+    parse_log(new_log_content, args)
 
 
-def parse_log(log_content: str):
-    for line in log_content.splitlines():
+def parse_log(log_content: str, args: argparse.Namespace):
+    log_lines = log_content.splitlines()
+    tail = len(log_lines)
+    if args.tail:
+        tail = args.tail
+
+    for line in log_lines[-tail:]:
         parse_log_line(line)
 
 


### PR DESCRIPTION
I have added a simple command to display the last N lines of the log file. I find this pretty useful everytime I need to work with log files, even on ones using short log rotations. I do not like to stare at my terminal spitting the whole log file.

The implementation is very simple, did now want to "spent" time on this. This is causing that if the last N lines are skipped by `parse_log_line` function, the program just shows nothing, There are a lot of ways to fix this/improve the general script but do not know if this is worth the time, let me know in case this would be interesting.